### PR TITLE
Don't show revoked keys when creating a tipbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mailgun-js": "^0.6.7",
     "mold-source-map": "^0.3.0",
     "moment": "^2.10.2",
-    "node-pgp-search": "0.1.5",
+    "node-pgp-search": "0.1.6",
     "nodemailer": "^1.3.4",
     "numbro": "1.1.1",
     "request": "^2.58.0",


### PR DESCRIPTION
Hi,

I fixed the upstream node-pgp-search package to allow the keys' flag to be gathered when calling index(). In this diff, I take advantage of this to filter out revoked keys from the list when creating a tipbox.

Also, I think using the exact=on flag when calling the search to the PGP server should ensure we're only matching the email the user is trying to use and not someone else's potential key.

Let me know what you guys think,

--Thomas
